### PR TITLE
fix: Search form is not target of hx-boost

### DIFF
--- a/src/atsphinx/htmx_boost/__init__.py
+++ b/src/atsphinx/htmx_boost/__init__.py
@@ -15,10 +15,8 @@ class WithHtmxTemplateLoader(BuiltinTemplateLoader):  # noqa: D101
             return out
         soup = BeautifulSoup(out, "html.parser")
         soup.body["hx-boost"] = "true"
-        # Exclude 'search' page from boost targets
-        search_form = soup.find("form", {"action": context["pathto"]("search")})
-        if search_form:
-            search_form["hx-boost"] = "false"
+        for form in soup.find_all("form"):
+            form["hx-boost"] = "false"
         return soup.prettify()
 
 

--- a/src/atsphinx/htmx_boost/__init__.py
+++ b/src/atsphinx/htmx_boost/__init__.py
@@ -15,6 +15,10 @@ class WithHtmxTemplateLoader(BuiltinTemplateLoader):  # noqa: D101
             return out
         soup = BeautifulSoup(out, "html.parser")
         soup.body["hx-boost"] = "true"
+        # Exclude 'search' page from boost targets
+        search_form = soup.find("form", {"action": context["pathto"]("search")})
+        if search_form:
+            search_form["hx-boost"] = "false"
         return soup.prettify()
 
 


### PR DESCRIPTION
This is for fix #1.

Currently, test with Furo theme.